### PR TITLE
fix: Ensure database initialization on Vercel startup

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -365,11 +365,14 @@ def create_tables_and_seed_data():
 # Database initialization needs to be handled differently for serverless.
 # For now, we can call it manually or via a separate script for local dev.
 if __name__ == '__main__':
-    create_tables_and_seed_data() # Call the helper function
+    # create_tables_and_seed_data() # Call is now above, will run before local dev server starts
     app.run(debug=True)
 
 # Expose the Flask app instance for Vercel
-application = app
+application = app 
+
+# Initialize database and tables on app startup for serverless environment
+create_tables_and_seed_data() # The function handles its own app context
 
 @app.route('/user/<username>')
 @login_required # Or remove if profiles can be public


### PR DESCRIPTION
Resolves an `sqlite3.OperationalError: no such table` error when deployed to Vercel.

The `create_tables_and_seed_data()` function, which calls `db.create_all()` and seeds initial data, was previously only called within the `if __name__ == "__main__":` block. This block does not execute in Vercel's serverless environment when the application is imported.

This commit moves the call to `create_tables_and_seed_data()` to the global scope after the Flask `app` (aliased as `application`) is defined. This ensures that database tables are created and initial data is seeded every time a new serverless instance starts, making the application functional on Vercel with SQLite on its ephemeral `/tmp` filesystem.

The `create_tables_and_seed_data` function itself was reviewed and deemed suitable for this execution context, as it already checks for existing data before seeding.